### PR TITLE
Arcarum Sandbox Defender Logic

### DIFF
--- a/src-tauri/backend/bot/combat_mode.py
+++ b/src-tauri/backend/bot/combat_mode.py
@@ -881,7 +881,7 @@ class CombatMode:
     ######################################################################
 
     @staticmethod
-    def start_combat_mode(script_commands: List[str] = None, is_nightmare: bool = False):
+    def start_combat_mode(script_commands: List[str] = None, is_nightmare: bool = False, is_defender: bool = False):
         """Start Combat Mode with the given script file path. Start reading through the text file line by line and have the bot proceed with the commands accordingly.
 
         Args:
@@ -916,6 +916,9 @@ class CombatMode:
             if is_nightmare:
                 MessageLog.print_message(f"Name of Nightmare combat script loaded: {Settings.nightmare_combat_script_name}")
                 command_list = copy.deepcopy(Settings.nightmare_combat_script)
+            elif is_defender:
+                MessageLog.print_message(f"Name of Defender combat script loaded: {Settings.defender_combat_script_name}")
+                command_list = copy.deepcopy(Settings.defender_combat_script)
             else:
                 MessageLog.print_message(f"Name of combat script loaded: {Settings.combat_script_name}")
                 command_list = copy.deepcopy(Settings.combat_script)

--- a/src-tauri/backend/bot/combat_mode.py
+++ b/src-tauri/backend/bot/combat_mode.py
@@ -887,6 +887,7 @@ class CombatMode:
         Args:
             script_commands (List[str]): List of script commands to use instead of reading from a text file. Defaults to None.
             is_nightmare (bool, optional): If Combat Mode is being used for a Nightmare, determines the method of reading the script file.
+            is_defender (bool, optional): If Combat Mode is being used for a Defender, determines the method of reading the script file.
 
         Returns:
             (bool): Return True if Combat Mode was successful. Else, return False if the Party wiped or backed out without retreating.

--- a/src-tauri/backend/bot/game.py
+++ b/src-tauri/backend/bot/game.py
@@ -526,7 +526,7 @@ class Game:
         return None
 
     @staticmethod
-    def collect_loot(is_completed: bool, is_pending_battle: bool = False, is_event_nightmare: bool = False, skip_info: bool = False, skip_popup_check: bool = False):
+    def collect_loot(is_completed: bool, is_pending_battle: bool = False, is_event_nightmare: bool = False, skip_info: bool = False, skip_popup_check: bool = False, is_defender: bool = False):
         """Collects the loot from the Results screen while clicking away any dialog popups while updating the internal item count.
         
         Args:
@@ -563,7 +563,7 @@ class Game:
                     MessageLog.print_message("[DEBUG] Have not detected the Loot Collection screen yet...")
 
         # Now that the bot is at the Loot Collected screen, detect any user-specified items.
-        if is_completed and not is_pending_battle and not is_event_nightmare:
+        if is_completed and not is_pending_battle and not is_event_nightmare and not is_defender:
             MessageLog.print_message("\n[INFO] Detecting if any user-specified loot dropped from this run...")
             if Settings.item_name != "EXP" and Settings.item_name != "Angel Halo Weapons" and Settings.item_name != "Repeated Runs":
                 temp_amount = ImageUtils.find_farmed_items(Settings.item_name)
@@ -581,7 +581,7 @@ class Game:
 
             Settings.item_amount_farmed += temp_amount
 
-        if is_completed and not is_pending_battle and not is_event_nightmare and not skip_info:
+        if is_completed and not is_pending_battle and not is_event_nightmare and not skip_info and not is_defender:
             if Settings.item_name != "EXP" and Settings.item_name != "Angel Halo Weapons" and Settings.item_name != "Repeated Runs":
                 MessageLog.print_message("\n**********************************************************************")
                 MessageLog.print_message("**********************************************************************")
@@ -643,7 +643,17 @@ class Game:
                                          f"**[{Settings.item_amount_farmed} / {Settings.item_amount_to_farm}]**"
 
                     Game._discord_queue.put(discord_string)
-
+        elif is_defender:
+                Settings.engaged_defender_battle = False
+                Settings.number_of_defeated_defenders+=1
+                MessageLog.print_message("\n**********************************************************************")
+                MessageLog.print_message("**********************************************************************")
+                MessageLog.print_message(f"[FARM] Farming Mode: {Settings.farming_mode}")
+                MessageLog.print_message(f"[FARM] Mission: {Settings.mission_name}")
+                MessageLog.print_message(f"[FARM] Summons: {Settings.summon_list}")
+                MessageLog.print_message(f"[FARM] Amount of Defenders defeated: {Settings.number_of_defeated_defenders}/{Settings.number_of_defenders}")
+                MessageLog.print_message("**********************************************************************")
+                MessageLog.print_message("**********************************************************************\n")
         return None
 
     @staticmethod

--- a/src-tauri/backend/bot/game.py
+++ b/src-tauri/backend/bot/game.py
@@ -385,19 +385,20 @@ class Game:
         return None
 
     @staticmethod
-    def find_party_and_start_mission(group_number: int, party_number: int, tries: int = 30):
+    def find_party_and_start_mission(group_number: int, party_number: int, tries: int = 30, bypass_first_run: bool = False):
         """Select the specified Group and Party. It will then start the mission.
 
         Args:
-            group_number (int): The Group that the specified Party in in.
+            group_number (int): The Group that the specified Party is in.
             party_number (int): The specified Party to start the mission with.
             tries (int, optional): Number of tries to select a Set before failing. Defaults to 30.
+            bypass_first_run (bool, optional): Determines if the bot should reselect the party in subsequent runs. Defaults to False.
 
         Returns:
             (bool): Returns False if it detects the "Raid is full/Raid is already done" dialog. Otherwise, return True.
         """
         # Repeat runs already have the same party already selected.
-        if Settings.party_selection_first_run:
+        if Settings.party_selection_first_run or bypass_first_run:
             MessageLog.print_message(f"\n[INFO] Starting process to select Group {group_number}, Party {party_number}...")
 
             # Find the Group that the Party is in first. If the specified Group number is less than 8, it is in Set A. Otherwise, it is in Set B. If failed, alternate searching for Set A / Set B until

--- a/src-tauri/backend/bot/game.py
+++ b/src-tauri/backend/bot/game.py
@@ -644,16 +644,17 @@ class Game:
 
                     Game._discord_queue.put(discord_string)
         elif is_defender:
-                Settings.engaged_defender_battle = False
-                Settings.number_of_defeated_defenders+=1
-                MessageLog.print_message("\n**********************************************************************")
-                MessageLog.print_message("**********************************************************************")
-                MessageLog.print_message(f"[FARM] Farming Mode: {Settings.farming_mode}")
-                MessageLog.print_message(f"[FARM] Mission: {Settings.mission_name}")
-                MessageLog.print_message(f"[FARM] Summons: {Settings.summon_list}")
-                MessageLog.print_message(f"[FARM] Amount of Defenders defeated: {Settings.number_of_defeated_defenders}/{Settings.number_of_defenders}")
-                MessageLog.print_message("**********************************************************************")
-                MessageLog.print_message("**********************************************************************\n")
+            Settings.engaged_defender_battle = False
+            Settings.number_of_defeated_defenders += 1
+            MessageLog.print_message("\n**********************************************************************")
+            MessageLog.print_message("**********************************************************************")
+            MessageLog.print_message(f"[FARM] Farming Mode: {Settings.farming_mode}")
+            MessageLog.print_message(f"[FARM] Mission: {Settings.mission_name}")
+            MessageLog.print_message(f"[FARM] Summons: {Settings.summon_list}")
+            MessageLog.print_message(f"[FARM] Amount of Defenders defeated: {Settings.number_of_defeated_defenders}/{Settings.number_of_defenders}")
+            MessageLog.print_message("**********************************************************************")
+            MessageLog.print_message("**********************************************************************\n")
+
         return None
 
     @staticmethod

--- a/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
+++ b/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
@@ -537,7 +537,7 @@ class ArcarumSandbox:
         Game.wait(3.0)
 
         if Settings.engaged_defender_battle:
-            if Game.find_party_and_start_mission(Settings.defender_group_number, Settings.defender_party_number):
+            if Game.find_party_and_start_mission(Settings.defender_group_number, Settings.defender_party_number, bypass_first_run = True):
                 if CombatMode.start_combat_mode(is_defender = Settings.engaged_defender_battle):
                     Game.collect_loot(is_completed = True, is_defender = Settings.engaged_defender_battle)
         else:

--- a/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
+++ b/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
@@ -388,7 +388,7 @@ class ArcarumSandbox:
         action_locations: List[Tuple[int, ...]] = ImageUtils.find_all("arcarum_sandbox_action")
         if len(action_locations) == 1:
             MouseUtils.move_and_click_point(action_locations[0][0], action_locations[0][1], "arcarum_sandbox_action")
-        elif (Settings.enable_defender and Settings.number_of_defeated_defenders<Settings.number_of_defenders):
+        elif Settings.enable_defender and Settings.number_of_defeated_defenders < Settings.number_of_defenders:
             MouseUtils.move_and_click_point(action_locations[0][0], action_locations[0][1], "arcarum_sandbox_action")
             MessageLog.print_message(f"\n[ARCARUM.SANDBOX] Found Defender and fighting it...")
             Settings.engaged_defender_battle = True
@@ -536,9 +536,9 @@ class ArcarumSandbox:
 
         Game.wait(3.0)
 
-        if(Settings.engaged_defender_battle):
+        if Settings.engaged_defender_battle:
             if Game.find_party_and_start_mission(Settings.defender_group_number, Settings.defender_party_number):
-                if CombatMode.start_combat_mode(is_defender=Settings.engaged_defender_battle):
+                if CombatMode.start_combat_mode(is_defender = Settings.engaged_defender_battle):
                     Game.collect_loot(is_completed = True, is_defender = Settings.engaged_defender_battle)
         else:
             if Game.find_party_and_start_mission(Settings.group_number, Settings.party_number):

--- a/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
+++ b/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
@@ -388,6 +388,10 @@ class ArcarumSandbox:
         action_locations: List[Tuple[int, ...]] = ImageUtils.find_all("arcarum_sandbox_action")
         if len(action_locations) == 1:
             MouseUtils.move_and_click_point(action_locations[0][0], action_locations[0][1], "arcarum_sandbox_action")
+        elif (Settings.enable_defender and Settings.number_of_defeated_defenders<Settings.number_of_defenders):
+            MouseUtils.move_and_click_point(action_locations[0][0], action_locations[0][1], "arcarum_sandbox_action")
+            MessageLog.print_message(f"\n[ARCARUM.SANDBOX] Found Defender and fighting it...")
+            Settings.engaged_defender_battle = True
         else:
             MouseUtils.move_and_click_point(action_locations[1][0], action_locations[1][1], "arcarum_sandbox_action")
 
@@ -532,8 +536,13 @@ class ArcarumSandbox:
 
         Game.wait(3.0)
 
-        if Game.find_party_and_start_mission(Settings.group_number, Settings.party_number):
-            if CombatMode.start_combat_mode():
-                Game.collect_loot(is_completed = True)
+        if(Settings.engaged_defender_battle):
+            if Game.find_party_and_start_mission(Settings.defender_group_number, Settings.defender_party_number):
+                if CombatMode.start_combat_mode(is_defender=Settings.engaged_defender_battle):
+                    Game.collect_loot(is_completed = True, is_defender = Settings.engaged_defender_battle)
+        else:
+            if Game.find_party_and_start_mission(Settings.group_number, Settings.party_number):
+                if CombatMode.start_combat_mode():
+                    Game.collect_loot(is_completed = True)
 
         return None

--- a/src-tauri/backend/bot/game_modes/event.py
+++ b/src-tauri/backend/bot/game_modes/event.py
@@ -54,7 +54,7 @@ class Event:
                 # Once the bot is at the Summon Selection screen, select your Summon and Party and start the mission.
                 if ImageUtils.confirm_location("select_a_summon"):
                     Game.select_summon(Settings.nightmare_summon_list, Settings.nightmare_summon_elements_list)
-                    start_check = Game.find_party_and_start_mission(int(Settings.nightmare_group_number), int(Settings.nightmare_party_number))
+                    start_check = Game.find_party_and_start_mission(int(Settings.nightmare_group_number), int(Settings.nightmare_party_number), bypass_first_run = True)
 
                     # Once preparations are completed, start Combat Mode.
                     if start_check and CombatMode.start_combat_mode(is_nightmare = True):

--- a/src-tauri/backend/bot/game_modes/rotb.py
+++ b/src-tauri/backend/bot/game_modes/rotb.py
@@ -46,7 +46,7 @@ class RiseOfTheBeasts:
             # Once the bot is at the Summon Selection screen, select your Summon and Party and start the mission.
             if ImageUtils.confirm_location("select_a_summon"):
                 Game.select_summon(Settings.nightmare_summon_list, Settings.nightmare_summon_elements_list)
-                start_check = Game.find_party_and_start_mission(int(Settings.nightmare_group_number), int(Settings.nightmare_party_number))
+                start_check = Game.find_party_and_start_mission(int(Settings.nightmare_group_number), int(Settings.nightmare_party_number), bypass_first_run = True)
 
                 # Once preparations are completed, start Combat mode.
                 if start_check and CombatMode.start_combat_mode(is_nightmare = True):

--- a/src-tauri/backend/bot/game_modes/special.py
+++ b/src-tauri/backend/bot/game_modes/special.py
@@ -49,7 +49,7 @@ class Special:
             # Once the bot is at the Summon Selection screen, select your Summon and Party and start the mission.
             if ImageUtils.confirm_location("select_a_summon"):
                 Game.select_summon(Settings.nightmare_summon_list, Settings.nightmare_summon_elements_list)
-                start_check = Game.find_party_and_start_mission(int(Settings.nightmare_group_number), int(Settings.nightmare_party_number))
+                start_check = Game.find_party_and_start_mission(int(Settings.nightmare_group_number), int(Settings.nightmare_party_number), bypass_first_run = True)
 
                 # Once preparations are completed, start Combat Mode.
                 if start_check and CombatMode.start_combat_mode(is_nightmare = True):

--- a/src-tauri/backend/bot/game_modes/xeno_clash.py
+++ b/src-tauri/backend/bot/game_modes/xeno_clash.py
@@ -67,7 +67,7 @@ class XenoClash:
                 # Once the bot is at the Summon Selection screen, select your Summon and Party and start the mission.
                 if ImageUtils.confirm_location("select_a_summon"):
                     Game.select_summon(Settings.nightmare_summon_list, Settings.nightmare_summon_elements_list)
-                    start_check = Game.find_party_and_start_mission(int(Settings.nightmare_group_number), int(Settings.nightmare_party_number))
+                    start_check = Game.find_party_and_start_mission(int(Settings.nightmare_group_number), int(Settings.nightmare_party_number), bypass_first_run = True)
 
                     # Once preparations are completed, start Combat Mode.
                     if start_check and CombatMode.start_combat_mode(is_nightmare = True):

--- a/src-tauri/backend/utils/settings.py
+++ b/src-tauri/backend/utils/settings.py
@@ -112,6 +112,18 @@ class Settings:
         MessageLog.print_message(f"[NIGHTMARE] Settings initialized for {farming_mode}'s Nightmare...")
     # #### end of nightmare ####
 
+    # #### sandbox defender #### #
+    enable_defender: bool = dictor(_data, "sandbox.enableDefender", False)
+    _enable_custom_defender_settings: bool = dictor(_data, "sandbox.enableCustomDefenderSettings", False)
+    defender_combat_script_name: str = dictor(_data, "sandbox.defenderCombatScriptName", "")
+    defender_combat_script: List[str] = dictor(_data, "sandbox.defenderCombatScript", [])
+    number_of_defenders: int = dictor(_data, "sandbox.numberOfDefenders", 1)
+    defender_group_number: int = dictor(_data, "sandbox.defenderGroupNumber", 1)
+    defender_party_number: int = dictor(_data, "sandbox.defenderPartyNumber", 1)
+    number_of_defeated_defenders: int = 0
+    engaged_defender_battle: bool = False
+    # #### end of sandbox defender #### #
+
     # #### event ####
     enable_event_location_incrementation_by_one: bool = dictor(_data, "event.enableLocationIncrementByOne", False)
     enable_select_bottom_category: bool = dictor(_data, "selectBottomCategory", False)

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -59,11 +59,11 @@ export interface Settings {
     // Arcarum Sandbox settings
     sandbox: {
         enableDefender: boolean
-        enableCustomDefenderSettings: boolean,
+        enableCustomDefenderSettings: boolean
         numberOfDefenders: number
-        defenderCombatScriptName: string,
-        defenderCombatScript: string[],
-        defenderGroupNumber: number,
+        defenderCombatScriptName: string
+        defenderCombatScript: string[]
+        defenderGroupNumber: number
         defenderPartyNumber: number
     }
 
@@ -237,8 +237,8 @@ export const defaultSettings: Settings = {
         defenderCombatScriptName: "",
         defenderCombatScript: [],
         defenderGroupNumber: 1,
-        defenderPartyNumber: 1
-    }
+        defenderPartyNumber: 1,
+    },
 }
 
 interface IProviderProps {

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -56,6 +56,17 @@ export interface Settings {
         alternativeCombatScriptSelector: boolean
     }
 
+    // Arcarum Sandbox settings
+    sandbox: {
+        enableDefender: boolean
+        enableCustomDefenderSettings: boolean,
+        numberOfDefenders: number
+        defenderCombatScriptName: string,
+        defenderCombatScript: string[],
+        defenderGroupNumber: number,
+        defenderPartyNumber: number
+    }
+
     // Extra Settings related to Nightmares from certain Farming Modes.
     nightmare: {
         enableNightmare: boolean
@@ -219,6 +230,15 @@ export const defaultSettings: Settings = {
         adjustArcarumAction: 3,
         adjustArcarumStageEffect: 10,
     },
+    sandbox: {
+        enableDefender: false,
+        enableCustomDefenderSettings: false,
+        numberOfDefenders: 1,
+        defenderCombatScriptName: "",
+        defenderCombatScript: [],
+        defenderGroupNumber: 1,
+        defenderPartyNumber: 1
+    }
 }
 
 interface IProviderProps {

--- a/src/data/data.json
+++ b/src/data/data.json
@@ -938,243 +938,243 @@
     "Arcarum Sandbox": {
         "Slithering Seductress": {
             "map": "Zone Eletio",
-            "items": ["Fire Verum Proof","Repeated Runs"]
+            "items": ["Fire Verum Proof", "Repeated Runs"]
         },
         "Living Lightning Rod": {
             "map": "Zone Eletio",
-            "items": ["Lightborne Astra","Repeated Runs"]
+            "items": ["Lightborne Astra", "Repeated Runs"]
         },
         "Eletion Drake": {
             "map": "Zone Eletio",
-            "items": ["Sephira Stone","Repeated Runs"]
+            "items": ["Sephira Stone", "Repeated Runs"]
         },
         "Paradoxical Gate": {
             "map": "Zone Eletio",
-            "items": ["Flameborne Astra","Repeated Runs"]
+            "items": ["Flameborne Astra", "Repeated Runs"]
         },
         "Blazing Everwing": {
             "map": "Zone Eletio",
-            "items": ["Devil Idean","Repeated Runs"]
+            "items": ["Devil Idean", "Repeated Runs"]
         },
         "Death Seer": {
             "map": "Zone Eletio",
-            "items": ["Supreme Merit","Repeated Runs"]
+            "items": ["Supreme Merit", "Repeated Runs"]
         },
         "Hundred-Armed Hulk": {
             "map": "Zone Eletio",
-            "items": ["Star Idean","Repeated Runs"]
+            "items": ["Star Idean", "Repeated Runs"]
         },
         "Terror Trifecta": {
             "map": "Zone Eletio",
-            "items": ["Fire Quartz","Repeated Runs"]
+            "items": ["Fire Quartz", "Repeated Runs"]
         },
         "Rageborn One": {
             "map": "Zone Eletio",
-            "items": ["Sun Idean","Repeated Runs"]
+            "items": ["Sun Idean", "Repeated Runs"]
         },
         "Trident Grandmaster": {
             "map": "Zone Faym",
-            "items": ["Water Verum Proof","Repeated Runs"]
+            "items": ["Water Verum Proof", "Repeated Runs"]
         },
         "Hoarfrost Icequeen": {
             "map": "Zone Faym",
-            "items": ["Justice Idean","Repeated Runs"]
+            "items": ["Justice Idean", "Repeated Runs"]
         },
         "Oceanic Archon": {
             "map": "Zone Faym",
-            "items": ["Sephira Stone","Repeated Runs"]
+            "items": ["Sephira Stone", "Repeated Runs"]
         },
         "Farsea Predator": {
             "map": "Zone Faym",
-            "items": ["Supreme Merit","Repeated Runs"]
+            "items": ["Supreme Merit", "Repeated Runs"]
         },
         "Faymian Fortress": {
             "map": "Zone Faym",
-            "items": ["Moon Idean","Repeated Runs"]
+            "items": ["Moon Idean", "Repeated Runs"]
         },
         "Draconic Simulacrum": {
             "map": "Zone Faym",
-            "items": ["Darkborne Astra","Repeated Runs"]
+            "items": ["Darkborne Astra", "Repeated Runs"]
         },
         "Azureflame Dragon": {
             "map": "Zone Faym",
-            "items": ["Aquaborne Astra","Repeated Runs"]
+            "items": ["Aquaborne Astra", "Repeated Runs"]
         },
         "Eyes of Sorrow": {
             "map": "Zone Faym",
-            "items": ["Water Quartz","Repeated Runs"]
+            "items": ["Water Quartz", "Repeated Runs"]
         },
         "Mud Shearwielder": {
             "map": "Zone Faym",
-            "items": ["Death Idean","Repeated Runs"]
+            "items": ["Death Idean", "Repeated Runs"]
         },
         "Avatar of Avarice": {
             "map": "Zone Goliath",
-            "items": ["Earthborne Astra","Repeated Runs"]
+            "items": ["Earthborne Astra", "Repeated Runs"]
         },
         "Temptation's Guide": {
             "map": "Zone Goliath",
-            "items": ["Supreme Merit","Repeated Runs"]
+            "items": ["Supreme Merit", "Repeated Runs"]
         },
         "World's Veil": {
             "map": "Zone Goliath",
-            "items": ["Hanged Man Idean","Repeated Runs"]
+            "items": ["Hanged Man Idean", "Repeated Runs"]
         },
         "Goliath Keeper": {
             "map": "Zone Goliath",
-            "items": ["Earth Quartz","Repeated Runs"]
+            "items": ["Earth Quartz", "Repeated Runs"]
         },
         "Bloodstained Barbarian": {
             "map": "Zone Goliath",
-            "items": ["Sephira Stone","Repeated Runs"]
+            "items": ["Sephira Stone", "Repeated Runs"]
         },
         "Frenzied Howler": {
             "map": "Zone Goliath",
-            "items": ["Darkborne Astra","Repeated Runs"]
+            "items": ["Darkborne Astra", "Repeated Runs"]
         },
         "Goliath Vanguard": {
             "map": "Zone Goliath",
-            "items": ["Tower Idean","Repeated Runs"]
+            "items": ["Tower Idean", "Repeated Runs"]
         },
         "Vestige of Truth": {
             "map": "Zone Goliath",
-            "items": ["Earth Verum Proof","Repeated Runs"]
+            "items": ["Earth Verum Proof", "Repeated Runs"]
         },
         "Writhing Despair": {
             "map": "Zone Goliath",
-            "items": ["Death Idean","Repeated Runs"]
+            "items": ["Death Idean", "Repeated Runs"]
         },
         "Vengeful Demigod": {
             "map": "Zone Harbinger",
-            "items": ["Sephira Stone","Repeated Runs"]
+            "items": ["Sephira Stone", "Repeated Runs"]
         },
         "Dirgesinger": {
             "map": "Zone Harbinger",
-            "items": ["Supreme Merit","Repeated Runs"]
+            "items": ["Supreme Merit", "Repeated Runs"]
         },
         "Wildwind Conjurer/Fullthunder Conjurer": {
             "map": "Zone Harbinger",
-            "items": ["Judgement Idean","Repeated Runs"]
+            "items": ["Judgement Idean", "Repeated Runs"]
         },
         "Harbinger Simurgh": {
             "map": "Zone Harbinger",
-            "items": ["Temperance Idean","Repeated Runs"]
+            "items": ["Temperance Idean", "Repeated Runs"]
         },
         "Harbinger Hardwood": {
             "map": "Zone Harbinger",
-            "items": ["Wind Verum Proof","Repeated Runs"]
+            "items": ["Wind Verum Proof", "Repeated Runs"]
         },
         "Demanding Stormgod": {
             "map": "Zone Harbinger",
-            "items": ["Windborne Astra","Repeated Runs"]
+            "items": ["Windborne Astra", "Repeated Runs"]
         },
         "Harbinger Tyrant": {
             "map": "Zone Harbinger",
-            "items": ["Lightborne Astra","Repeated Runs"]
+            "items": ["Lightborne Astra", "Repeated Runs"]
         },
         "Phantasmagoric Aberration": {
             "map": "Zone Harbinger",
-            "items": ["Light Quartz","Repeated Runs"]
+            "items": ["Light Quartz", "Repeated Runs"]
         },
         "Dimensional Riftwalker": {
             "map": "Zone Harbinger",
-            "items": ["Star Idean","Repeated Runs"]
+            "items": ["Star Idean", "Repeated Runs"]
         },
         "Infernal Hellbeast": {
             "map": "Zone Invidia",
-            "items": ["Sephira Stone","Flameborne Astra","Devil Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Flameborne Astra", "Devil Idean", "Repeated Runs"]
         },
         "Spikeball": {
             "map": "Zone Invidia",
-            "items": ["Sephira Stone","Flameborne Astra","Sun Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Flameborne Astra", "Sun Idean", "Repeated Runs"]
         },
         "Blushing Groom": {
             "map": "Zone Invidia",
-            "items": ["Sephira Stone","Flameborne Astra","Devil Idean","Sun Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Flameborne Astra", "Devil Idean", "Sun Idean", "Repeated Runs"]
         },
         "Unworldly Guardian": {
             "map": "Zone Invidia",
-            "items": ["Sephira Stone","Lightborne Astra","Star Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Lightborne Astra", "Star Idean", "Repeated Runs"]
         },
         "Deva of Wisdom": {
             "map": "Zone Invidia",
-            "items": ["Sephira Stone","Lightborne Astra","Star Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Lightborne Astra", "Star Idean", "Repeated Runs"]
         },
         "Sword of Aberration": {
             "map": "Zone Invidia",
-            "items": ["Sephira Stone","Lightborne Astra","Star Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Lightborne Astra", "Star Idean", "Repeated Runs"]
         },
         "Glacial Hellbeast": {
             "map": "Zone Joculator",
-            "items": ["Sephira Stone","Aquaborne Astra","Justice Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Aquaborne Astra", "Justice Idean", "Repeated Runs"]
         },
         "Giant Sea Plant": {
             "map": "Zone Joculator",
-            "items": ["Sephira Stone","Aquaborne Astra","Moon Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Aquaborne Astra", "Moon Idean", "Repeated Runs"]
         },
         "Maiden of the Depths": {
             "map": "Zone Joculator",
-            "items": ["Sephira Stone","Aquaborne Astra","Justice Idean","Moon Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Aquaborne Astra", "Justice Idean", "Moon Idean", "Repeated Runs"]
         },
         "Bloody Soothsayer": {
             "map": "Zone Joculator",
-            "items": ["Sephira Stone","Darkborne Astra","Death Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Darkborne Astra", "Death Idean", "Repeated Runs"]
         },
         "Nebulous One": {
             "map": "Zone Joculator",
-            "items": ["Sephira Stone","Darkborne Astra","Death Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Darkborne Astra", "Death Idean", "Repeated Runs"]
         },
         "Dreadful Scourge": {
             "map": "Zone Joculator",
-            "items": ["Sephira Stone","Darkborne Astra","Death Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Darkborne Astra", "Death Idean", "Repeated Runs"]
         },
         "Bedeviled Plague": {
             "map": "Zone Kalendae",
-            "items": ["Sephira Stone","Earthborne Astra","Hanged Man Idean","Tower Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Earthborne Astra", "Hanged Man Idean", "Tower Idean", "Repeated Runs"]
         },
         "Tainted Hellmaiden": {
             "map": "Zone Kalendae",
-            "items": ["Sephira Stone","Earthborne Astra","Hanged Man Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Earthborne Astra", "Hanged Man Idean", "Repeated Runs"]
         },
         "Watcher from Above": {
             "map": "Zone Kalendae",
-            "items": ["Sephira Stone","Earthborne Astra","Tower Idean", "Repeated Runs"]
+            "items": ["Sephira Stone", "Earthborne Astra", "Tower Idean", "Repeated Runs"]
         },
         "Scintillant Matter": {
             "map": "Zone Kalendae",
-            "items": ["Sephira Stone","Darkborne Astra","Death Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Darkborne Astra", "Death Idean", "Repeated Runs"]
         },
         "Ebony Executioner": {
             "map": "Zone Kalendae",
-            "items": ["Sephira Stone","Darkborne Astra","Death Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Darkborne Astra", "Death Idean", "Repeated Runs"]
         },
         "Hellbeast of Doom": {
             "map": "Zone Kalendae",
-            "items": ["Sephira Stone","Darkborne Astra","Death Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Darkborne Astra", "Death Idean", "Repeated Runs"]
         },
         "Mounted Toxophilite": {
             "map": "Zone Liber",
-            "items": ["Sephira Stone","Windborne Astra","Temperance Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Windborne Astra", "Temperance Idean", "Repeated Runs"]
         },
         "Beetle of Damnation": {
             "map": "Zone Liber",
-            "items": ["Sephira Stone","Windborne Astra","Temperance Idean","Judgement Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Windborne Astra", "Temperance Idean", "Judgement Idean", "Repeated Runs"]
         },
         "Ageless Guardian Beast": {
             "map": "Zone Liber",
-            "items": ["Sephira Stone","Windborne Astra","Judgement Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Windborne Astra", "Judgement Idean", "Repeated Runs"]
         },
         "Solar Princess": {
             "map": "Zone Liber",
-            "items": ["Sephira Stone","Lightborne Astra","Star Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Lightborne Astra", "Star Idean", "Repeated Runs"]
         },
         "Drifting Blade Demon": {
             "map": "Zone Liber",
-            "items": ["Sephira Stone","Lightborne Astra","Star Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Lightborne Astra", "Star Idean", "Repeated Runs"]
         },
         "Simpering Beast": {
             "map": "Zone Liber",
-            "items": ["Sephira Stone","Lightborne Astra","Star Idean","Repeated Runs"]
+            "items": ["Sephira Stone", "Lightborne Astra", "Star Idean", "Repeated Runs"]
         }
     },
     "Generic": {

--- a/src/pages/ExtraSettings/index.tsx
+++ b/src/pages/ExtraSettings/index.tsx
@@ -768,8 +768,6 @@ const ExtraSettings = () => {
         }
     }
 
-    
-
     const renderMiscSettings = () => {
         return (
             <div id="misc">
@@ -814,10 +812,7 @@ const ExtraSettings = () => {
 
     //Arcarum sandbox settings
     const renderSandboxDefenderSettings = () => {
-        if (
-            bot.settings.sandbox.enableDefender &&
-            bot.settings.game.farmingMode === "Arcarum Sandbox"
-        ) {
+        if (bot.settings.sandbox.enableDefender && bot.settings.game.farmingMode === "Arcarum Sandbox") {
             var title: string = "Defender"
 
             return (
@@ -881,13 +876,13 @@ const ExtraSettings = () => {
 
                             <Grid container>
                                 <Grid item xs={6}>
-                                <TextField
+                                    <TextField
                                         label="How many times to run"
                                         variant="filled"
                                         type="number"
                                         error={bot.settings.sandbox.numberOfDefenders < 1}
                                         value={bot.settings.sandbox.numberOfDefenders}
-                                        inputProps={{ min: 1}}
+                                        inputProps={{ min: 1 }}
                                         onChange={(e) => bot.setSettings({ ...bot.settings, sandbox: { ...bot.settings.sandbox, numberOfDefenders: parseInt(e.target.value) } })}
                                         className="textfield"
                                     />
@@ -932,7 +927,6 @@ const ExtraSettings = () => {
             )
         }
     }
-
 
     // Attempt to kill the bot process if it is still active.
     const handleStop = async () => {

--- a/src/pages/ExtraSettings/index.tsx
+++ b/src/pages/ExtraSettings/index.tsx
@@ -113,6 +113,76 @@ const ExtraSettings = () => {
             })
     }
 
+    // Load the selected combat script text file.
+    const loadDefenderCombatScript = (event: React.ChangeEvent<HTMLInputElement>) => {
+        var files = event.currentTarget.files
+        if (files !== null && files.length !== 0) {
+            var selectedFile = files[0]
+            if (selectedFile === null || selectedFile === undefined) {
+                // Reset the defender combat script selected if none was selected from the file picker dialog.
+                bot.setSettings({ ...bot.settings, sandbox: { ...bot.settings.sandbox, defenderCombatScriptName: "", defenderCombatScript: [] } })
+            } else {
+                // Create the FileReader object and setup the function that will run after the FileReader reads the text file.
+                var reader = new FileReader()
+                reader.onload = function (loadedEvent) {
+                    if (loadedEvent.target?.result !== null && loadedEvent.target?.result !== undefined) {
+                        console.log("Loaded Sandbox Defender Combat Script: ", loadedEvent.target.result)
+                        const newCombatScript: string[] = loadedEvent.target.result.toString().split("\r\n")
+                        bot.setSettings({ ...bot.settings, sandbox: { ...bot.settings.sandbox, defenderCombatScriptName: selectedFile.name, defenderCombatScript: newCombatScript } })
+                    } else {
+                        console.log("Failed to read Sandbox Defender combat script. Reseting to default empty combat script...")
+                        bot.setSettings({ ...bot.settings, sandbox: { ...bot.settings.sandbox, defenderCombatScriptName: "", defenderCombatScript: [] } })
+                    }
+                }
+
+                // Read the text contents of the file.
+                reader.readAsText(selectedFile)
+            }
+        } else {
+            console.log("No file selected. Reseting to default empty combat script...")
+            bot.setSettings({ ...bot.settings, sandbox: { ...bot.settings.sandbox, defenderCombatScriptName: "", defenderCombatScript: [] } })
+        }
+    }
+
+    const loadDefenderCombatScriptAlternative = () => {
+        // Use an alternative file picker for selecting the combat script.
+        let filter: DialogFilter = {
+            extensions: ["txt"],
+            name: "Combat Script filter",
+        }
+
+        open({ defaultPath: undefined, filters: [filter], multiple: false })
+            .then((filePath) => {
+                if (typeof filePath === "string") {
+                    readTextFile(filePath)
+                        .then((data) => {
+                            console.log("Loaded Sandbox Defender Combat Script via alternative method: ", data)
+                            const newCombatScript: string[] = data
+                                .toString()
+                                .replace(/\r\n/g, "\n") // Replace LF with CRLF.
+                                .replace(/[\r\n]/g, "\n")
+                                .replace("\t", "") // Replace tab characters.
+                                .replace(/\t/g, "")
+                                .split("\n")
+                            bot.setSettings({
+                                ...bot.settings,
+                                sandbox: { ...bot.settings.sandbox, defenderCombatScriptName: filePath.replace(/^.*[\\/]/, ""), defenderCombatScript: newCombatScript },
+                            })
+                        })
+                        .catch((err) => {
+                            console.log(`Failed to read Sandbox Defender combat script via alternative method: ${err}\n\nReseting to default empty combat script...`)
+                            bot.setSettings({ ...bot.settings, sandbox: { ...bot.settings.sandbox, defenderCombatScriptName: "", defenderCombatScript: [] } })
+                        })
+                } else {
+                    console.log(`No file selected.\n\nReseting to default empty combat script...`)
+                    bot.setSettings({ ...bot.settings, sandbox: { ...bot.settings.sandbox, defenderCombatScriptName: "", defenderCombatScript: [] } })
+                }
+            })
+            .catch((e) => {
+                console.log("Error while resolving the path to the combat script: ", e)
+            })
+    }
+
     // Render settings for Twitter.
     const renderTwitterSettings = () => {
         return (
@@ -698,6 +768,8 @@ const ExtraSettings = () => {
         }
     }
 
+    
+
     const renderMiscSettings = () => {
         return (
             <div id="misc">
@@ -739,6 +811,128 @@ const ExtraSettings = () => {
             </div>
         )
     }
+
+    //Arcarum sandbox settings
+    const renderSandboxDefenderSettings = () => {
+        if (
+            bot.settings.sandbox.enableDefender &&
+            bot.settings.game.farmingMode === "Arcarum Sandbox"
+        ) {
+            var title: string = "Defender"
+
+            return (
+                <div id="defender">
+                    <Typography variant="h6" gutterBottom component="div" className="sectionTitle">
+                        {title} Settings <Iconify icon="ri:sword-fill" className="sectionTitleIcon" />
+                    </Typography>
+
+                    <Divider />
+
+                    <Typography variant="subtitle1" gutterBottom component="div" color="text.secondary">
+                        If none of these settings are changed, then the bot will reuse the settings for the Farming Mode.
+                    </Typography>
+
+                    <FormGroup sx={{ paddingBottom: "16px" }}>
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={bot.settings.sandbox.enableCustomDefenderSettings}
+                                    onChange={(e) => bot.setSettings({ ...bot.settings, sandbox: { ...bot.settings.sandbox, enableCustomDefenderSettings: e.target.checked } })}
+                                />
+                            }
+                            label={`Enable Custom Settings for ${title}`}
+                        />
+                        <FormHelperText>Enable customizing individual settings for {title}</FormHelperText>
+                    </FormGroup>
+
+                    {bot.settings.sandbox.enableCustomDefenderSettings ? (
+                        <Stack spacing={2}>
+                            <Grid container>
+                                <Grid item xs={6}>
+                                    {!bot.settings.misc.alternativeCombatScriptSelector ? (
+                                        <div>
+                                            <Input ref={inputRef} accept=".txt" id="combat-script-loader" type="file" onChange={(e) => loadDefenderCombatScript(e)} />
+                                            <TextField
+                                                variant="filled"
+                                                label="Defender Combat Script"
+                                                value={bot.settings.sandbox.defenderCombatScriptName !== "" ? bot.settings.sandbox.defenderCombatScriptName : "None Selected"}
+                                                inputProps={{ readOnly: true }}
+                                                InputLabelProps={{ shrink: true }}
+                                                helperText="Select a Combat Script"
+                                                onClick={() => inputRef.current?.click()}
+                                                fullWidth
+                                            />
+                                        </div>
+                                    ) : (
+                                        <TextField
+                                            variant="filled"
+                                            label="Defender Combat Script"
+                                            value={bot.settings.sandbox.defenderCombatScriptName !== "" ? bot.settings.sandbox.defenderCombatScriptName : "None Selected"}
+                                            inputProps={{ readOnly: true }}
+                                            InputLabelProps={{ shrink: true }}
+                                            helperText="Select a Combat Script (alternative method)"
+                                            onClick={() => loadDefenderCombatScriptAlternative()}
+                                            fullWidth
+                                        />
+                                    )}
+                                </Grid>
+                                <Grid item xs />
+                            </Grid>
+
+                            <Grid container>
+                                <Grid item xs={6}>
+                                <TextField
+                                        label="How many times to run"
+                                        variant="filled"
+                                        type="number"
+                                        error={bot.settings.sandbox.numberOfDefenders < 1}
+                                        value={bot.settings.sandbox.numberOfDefenders}
+                                        inputProps={{ min: 1}}
+                                        onChange={(e) => bot.setSettings({ ...bot.settings, sandbox: { ...bot.settings.sandbox, numberOfDefenders: parseInt(e.target.value) } })}
+                                        className="textfield"
+                                    />
+                                </Grid>
+                                <Grid item xs />
+                            </Grid>
+
+                            <Grid container direction="row">
+                                <Grid item id="gridItemDefenderGroup" xs={4}>
+                                    <TextField
+                                        label="Group #"
+                                        variant="filled"
+                                        type="number"
+                                        error={bot.settings.sandbox.defenderGroupNumber < 1 || bot.settings.sandbox.defenderGroupNumber > 7}
+                                        value={bot.settings.sandbox.defenderGroupNumber}
+                                        inputProps={{ min: 1, max: 7 }}
+                                        onChange={(e) => bot.setSettings({ ...bot.settings, sandbox: { ...bot.settings.sandbox, defenderGroupNumber: parseInt(e.target.value) } })}
+                                        helperText="From 1 to 7"
+                                        className="textfield"
+                                    />
+                                </Grid>
+
+                                <Grid item xs={8} />
+
+                                <Grid item id="gridItemDefenderParty" xs={4}>
+                                    <TextField
+                                        label="Party #"
+                                        variant="filled"
+                                        type="number"
+                                        error={bot.settings.sandbox.defenderPartyNumber < 1 || bot.settings.sandbox.defenderPartyNumber > 6}
+                                        value={bot.settings.sandbox.defenderPartyNumber}
+                                        inputProps={{ min: 1, max: 6 }}
+                                        onChange={(e) => bot.setSettings({ ...bot.settings, sandbox: { ...bot.settings.sandbox, defenderPartyNumber: parseInt(e.target.value) } })}
+                                        helperText="From 1 to 6"
+                                        className="textfield"
+                                    />
+                                </Grid>
+                            </Grid>
+                        </Stack>
+                    ) : null}
+                </div>
+            )
+        }
+    }
+
 
     // Attempt to kill the bot process if it is still active.
     const handleStop = async () => {
@@ -851,6 +1045,8 @@ const ExtraSettings = () => {
 
                 <Stack spacing={2} className="extraSettingsWrapper">
                     {renderNightmareSettings()}
+
+                    {renderSandboxDefenderSettings()}
 
                     {renderTwitterSettings()}
 

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -319,8 +319,8 @@ const Settings = () => {
                                     defenderCombatScriptName: "",
                                     defenderCombatScript: [],
                                     defenderGroupNumber: 1,
-                                    defenderPartyNumber: 1
-                                }
+                                    defenderPartyNumber: 1,
+                                },
                             })
                         }}
                         helperText="Please select the Farming Mode"
@@ -385,7 +385,7 @@ const Settings = () => {
                         </FormGroup>
                     ) : null}
 
-                    {botStateContext.settings.game.farmingMode === "Arcarum Sandbox"  ? (
+                    {botStateContext.settings.game.farmingMode === "Arcarum Sandbox" ? (
                         <FormGroup sx={{ paddingBottom: "16px" }}>
                             <FormControlLabel
                                 control={

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -311,6 +311,16 @@ const Settings = () => {
                                     nightmareGroupNumber: 1,
                                     nightmarePartyNumber: 1,
                                 },
+                                sandbox: {
+                                    ...botStateContext.settings.sandbox,
+                                    enableDefender: false,
+                                    enableCustomDefenderSettings: false,
+                                    numberOfDefenders: 1,
+                                    defenderCombatScriptName: "",
+                                    defenderCombatScript: [],
+                                    defenderGroupNumber: 1,
+                                    defenderPartyNumber: 1
+                                }
                             })
                         }}
                         helperText="Please select the Farming Mode"
@@ -370,6 +380,23 @@ const Settings = () => {
                                     />
                                 }
                                 label="Enable Nightmare Settings"
+                            />
+                            <FormHelperText>Enable additional settings to show up in the Extra Settings page.</FormHelperText>
+                        </FormGroup>
+                    ) : null}
+
+                    {botStateContext.settings.game.farmingMode === "Arcarum Sandbox"  ? (
+                        <FormGroup sx={{ paddingBottom: "16px" }}>
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        checked={botStateContext.settings.sandbox.enableDefender}
+                                        onChange={(e) =>
+                                            botStateContext.setSettings({ ...botStateContext.settings, sandbox: { ...botStateContext.settings.sandbox, enableDefender: e.target.checked } })
+                                        }
+                                    />
+                                }
+                                label="Enable Defender settings"
                             />
                             <FormHelperText>Enable additional settings to show up in the Extra Settings page.</FormHelperText>
                         </FormGroup>


### PR DESCRIPTION
Implemented logic to be able to fight Defenders in Arcarum Sandbox.
It works the same way as Nightmare settings except that there's no Summons list but you can choose how many times to fight defenders.

Known bugs: just like with Nightmare settings, it won't choose the requested party if Nightmare/Defender isn't the first run of the bot.
This is caused by the is_first_run variable.