### PR TITLE
Typo fix and coordinates fix

### DIFF
--- a/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
+++ b/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
@@ -153,7 +153,7 @@ class ArcarumSandbox:
         "Goliath Vanguard": {
             "section": 1,
             "x": 65,
-            "y": 390
+            "y": 360
         },
         "Vestige of Truth": {
             "section": 2,

--- a/src/data/data.json
+++ b/src/data/data.json
@@ -1004,7 +1004,7 @@
             "map": "Zone Faym",
             "items": ["Water Quartz", "Repeated Runs"]
         },
-        "Mud Shearwielder": {
+        "Mad Shearwielder": {
             "map": "Zone Faym",
             "items": ["Death Idean", "Repeated Runs"]
         },


### PR DESCRIPTION
Typo fix for Mad Shearwielder and Y coordinate fix for Goliath Vanguard