### PR TITLE
Gold chest opening for replicard sandbox

### DIFF
--- a/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
+++ b/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
@@ -557,7 +557,7 @@ class ArcarumSandbox:
 
     @staticmethod
     def _open_gold_chest():
-        """Clicks on the a gold chest.
+        """Clicks on a gold chest.
         If it is a mimic, fight it, if not, click ok.
 
         Returns:
@@ -580,9 +580,6 @@ class ArcarumSandbox:
         Game.wait(2.0)
         ArcarumSandbox._reset_position()
         ArcarumSandbox._navigate_to_mission()
-
-
-
 
     @staticmethod
     def start():

--- a/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
+++ b/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
@@ -572,6 +572,7 @@ class ArcarumSandbox:
         if Game.find_and_click_button("ok", suppress_error = True) is True:
             Game.wait(2.0)
             ArcarumSandbox._reset_position()
+            ArcarumSandbox._navigate_to_mission()
         else:
             MouseUtils.move_and_click_point(action_locations[0][0], action_locations[0][1], "arcarum_sandbox_action")
             if Game.find_party_and_start_mission(Settings.group_number, Settings.party_number):

--- a/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
+++ b/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
@@ -612,7 +612,7 @@ class ArcarumSandbox:
 
                 # Click away the Treasure popup if it shows up.
                 Game.find_and_click_button("ok", suppress_error = True)
-                if Game.find_and_click_button("arcarum_gold_chest") is True:
+                if Settings.enable_gold_chest and Game.find_and_click_button("arcarum_gold_chest") is True:
                     ArcarumSandbox._open_gold_chest()
                 else:
                     # Start the mission again.

--- a/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
+++ b/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
@@ -569,20 +569,17 @@ class ArcarumSandbox:
         MouseUtils.move_and_click_point(action_locations[0][0], action_locations[0][1], "arcarum_sandbox_action")
         Game.find_and_click_button("ok")
         Game.wait(3.0)
-        if Game.find_and_click_button("ok", suppress_error = True) is True:
-            Game.wait(2.0)
-            ArcarumSandbox._reset_position()
-            ArcarumSandbox._navigate_to_mission()
-        else:
+        if Game.find_and_click_button("ok", suppress_error = True) is False:
             MouseUtils.move_and_click_point(action_locations[0][0], action_locations[0][1], "arcarum_sandbox_action")
             Game.wait(3.0)
             if Game.find_party_and_start_mission(Settings.group_number, Settings.party_number):
                 if CombatMode.start_combat_mode():
                     Game.collect_loot(is_completed = True)
             Game.find_and_click_button("expedition")
-            Game.wait(2.0)
-            ArcarumSandbox._reset_position()
-            ArcarumSandbox._navigate_to_mission()
+                 
+        Game.wait(2.0)
+        ArcarumSandbox._reset_position()
+        ArcarumSandbox._navigate_to_mission()
 
 
 

--- a/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
+++ b/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
@@ -556,6 +556,36 @@ class ArcarumSandbox:
         return None
 
     @staticmethod
+    def _open_gold_chest():
+        """Clicks on the a gold chest.
+        If it is a mimic, fight it, if not, click ok.
+
+        Returns:
+            None
+        """
+        from bot.game import Game
+
+        action_locations: List[Tuple[int, ...]] = ImageUtils.find_all("arcarum_sandbox_action")
+        MouseUtils.move_and_click_point(action_locations[0][0], action_locations[0][1], "arcarum_sandbox_action")
+        Game.find_and_click_button("ok")
+        Game.wait(3.0)
+        if Game.find_and_click_button("ok", suppress_error = True) is True:
+            Game.wait(2.0)
+            ArcarumSandbox._reset_position()
+        else:
+            MouseUtils.move_and_click_point(action_locations[0][0], action_locations[0][1], "arcarum_sandbox_action")
+            if Game.find_party_and_start_mission(Settings.group_number, Settings.party_number):
+                if CombatMode.start_combat_mode():
+                    Game.collect_loot(is_completed = True)
+            Game.find_and_click_button("expedition")
+            Game.wait(2.0)
+            ArcarumSandbox._reset_position()
+            ArcarumSandbox._navigate_to_mission()
+
+
+
+
+    @staticmethod
     def start():
         """Starts the process of completing Arcarum Replicard Sandbox missions.
 
@@ -580,10 +610,12 @@ class ArcarumSandbox:
 
                 # Click away the Treasure popup if it shows up.
                 Game.find_and_click_button("ok", suppress_error = True)
-
-                # Start the mission again.
-                Game.wait(3.0)
-                ArcarumSandbox._navigate_to_mission(skip_to_action = True)
+                if Game.find_and_click_button("arcarum_gold_chest") is True:
+                    ArcarumSandbox._open_gold_chest()
+                else:
+                    # Start the mission again.
+                    Game.wait(3.0)
+                    ArcarumSandbox._navigate_to_mission(skip_to_action = True)
 
         # Refill AAP if needed.
         ArcarumSandbox._play_zone_boss()

--- a/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
+++ b/src-tauri/backend/bot/game_modes/arcarum_sandbox.py
@@ -575,6 +575,7 @@ class ArcarumSandbox:
             ArcarumSandbox._navigate_to_mission()
         else:
             MouseUtils.move_and_click_point(action_locations[0][0], action_locations[0][1], "arcarum_sandbox_action")
+            Game.wait(3.0)
             if Game.find_party_and_start_mission(Settings.group_number, Settings.party_number):
                 if CombatMode.start_combat_mode():
                     Game.collect_loot(is_completed = True)

--- a/src-tauri/backend/utils/settings.py
+++ b/src-tauri/backend/utils/settings.py
@@ -120,6 +120,7 @@ class Settings:
 
     # #### sandbox defender #### #
     enable_defender: bool = dictor(_data, "sandbox.enableDefender", False)
+    enable_gold_chest: bool = dictor(_data, "sandbox.enableGoldChest", False)
     _enable_custom_defender_settings: bool = dictor(_data, "sandbox.enableCustomDefenderSettings", False)
     defender_combat_script_name: str = dictor(_data, "sandbox.defenderCombatScriptName", "")
     defender_combat_script: List[str] = dictor(_data, "sandbox.defenderCombatScript", [])

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -67,6 +67,7 @@ export interface Settings {
     // Arcarum Sandbox settings
     sandbox: {
         enableDefender: boolean
+        enableGoldChest: boolean
         enableCustomDefenderSettings: boolean
         numberOfDefenders: number
         defenderCombatScriptName: string
@@ -253,6 +254,7 @@ export const defaultSettings: Settings = {
     },
     sandbox: {
         enableDefender: false,
+        enableGoldChest: false,
         enableCustomDefenderSettings: false,
         numberOfDefenders: 1,
         defenderCombatScriptName: "",

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -433,7 +433,7 @@ const Settings = () => {
                                 }
                                 label="Enable gold chest opening"
                             />
-                            <FormHelperText>Experimental, it uses default stuff for combat</FormHelperText>
+                            <FormHelperText>Experimental, it uses default party and the chosen script for combat.</FormHelperText>
                         </FormGroup>
                     ) : null}
 

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -314,6 +314,7 @@ const Settings = () => {
                                 sandbox: {
                                     ...botStateContext.settings.sandbox,
                                     enableDefender: false,
+                                    enableGoldChest: false,
                                     enableCustomDefenderSettings: false,
                                     numberOfDefenders: 1,
                                     defenderCombatScriptName: "",
@@ -416,6 +417,23 @@ const Settings = () => {
                                 label="Enable Defender settings"
                             />
                             <FormHelperText>Enable additional settings to show up in the Extra Settings page.</FormHelperText>
+                        </FormGroup>
+                    ) : null}
+
+                    {botStateContext.settings.game.farmingMode === "Arcarum Sandbox" ? (
+                        <FormGroup sx={{ paddingBottom: "16px" }}>
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        checked={botStateContext.settings.sandbox.enableGoldChest}
+                                        onChange={(e) =>
+                                            botStateContext.setSettings({ ...botStateContext.settings, sandbox: { ...botStateContext.settings.sandbox, enableGoldChest: e.target.checked } })
+                                        }
+                                    />
+                                }
+                                label="Enable gold chest opening"
+                            />
+                            <FormHelperText>Experimental, it uses default stuff for combat</FormHelperText>
                         </FormGroup>
                     ) : null}
 


### PR DESCRIPTION
For the image, it reuses the arcarum gold chest image since it is the same.
You can enable or disable it.

Given the mimic chest is a very easy mob, it is kinda stupid to change combat script and party.
As long as you've done it once, you get the right party and books.
For the combat script, you're mostly either doing Attack Reload (any small boss) or Full auto (Defender/Zone Boss), so it's not going to impact in any way.

If the mimic chest doesn't appear, it just defaults to the usual "close tab by clicking ok".

For both cases it then resets position and navigates again to the designed replicard mob.
This might make everything a bit slower but at least you get to be AP neutral.