### PR TITLE
Fix mouse clicks for non-bezier mouse movement setting

### DIFF
--- a/src-tauri/.gitignore
+++ b/src-tauri/.gitignore
@@ -4,3 +4,7 @@
 
 /backend/settings.json
 /temp/
+
+/backend/model/
+
+/results/

--- a/src-tauri/backend/utils/mouse_utils.py
+++ b/src-tauri/backend/utils/mouse_utils.py
@@ -92,14 +92,17 @@ class MouseUtils:
 
         MouseUtils.move_to(new_x, new_y, custom_mouse_speed = custom_mouse_speed)
 
-        pyautogui.mouseDown()
-        sleep(np.random.uniform(0.02, 0.12))
-        pyautogui.mouseUp()
-        for i in range(0, mouse_clicks - 1):
-            sleep(np.random.uniform(0.08, 0.16))
+        if Settings.enable_bezier_curve_mouse_movement:
             pyautogui.mouseDown()
             sleep(np.random.uniform(0.02, 0.12))
             pyautogui.mouseUp()
+            for i in range(0, mouse_clicks - 1):
+                sleep(np.random.uniform(0.08, 0.16))
+                pyautogui.mouseDown()
+                sleep(np.random.uniform(0.02, 0.12))
+                pyautogui.mouseUp()
+        else:
+            pyautogui.click(clicks=mouse_clicks)
 
         # This delay is necessary as ImageUtils will take the screenshot too fast and the bot will use the last frame before clicking to navigate.
         if custom_wait is not None:

--- a/src-tauri/backend/utils/mouse_utils.py
+++ b/src-tauri/backend/utils/mouse_utils.py
@@ -103,7 +103,7 @@ class MouseUtils:
 
         # This delay is necessary as ImageUtils will take the screenshot too fast and the bot will use the last frame before clicking to navigate.
         if custom_wait is not None:
-            sleep(max(0, custom_wait))
+            sleep(custom_wait)
             return
 
         from bot.game import Game

--- a/src-tauri/backend/utils/mouse_utils.py
+++ b/src-tauri/backend/utils/mouse_utils.py
@@ -22,7 +22,7 @@ class MouseUtils:
     # The lower the more smooth, the higher the more accurate to the speed
     mouse_smoothness = max(0.01, Settings.mouse_smoothness/100)
     # 1000 to 3000 is tested
-    mouse_speed = max(1000, 1000 * Settings.custom_mouse_speed)
+    mouse_speed = max(1000.0, 1000.0 * Settings.custom_mouse_speed)
 
     if Settings.enable_bezier_curve_mouse_movement is False:
         pyautogui.MINIMUM_DURATION = 0.1

--- a/src-tauri/backend/utils/mouse_utils.py
+++ b/src-tauri/backend/utils/mouse_utils.py
@@ -69,7 +69,7 @@ class MouseUtils:
         return None
 
     @staticmethod
-    def move_and_click_point(x: int, y: int, image_name: str, custom_mouse_speed: float = 0.0, mouse_clicks: int = np.random.randint(1, 3), custom_wait: Optional[float] = None):
+    def move_and_click_point(x: int, y: int, image_name: str, custom_mouse_speed: float = 0.0, mouse_clicks: int = 1, custom_wait: Optional[float] = None):
         """Move the cursor to the specified point on the screen and clicks it.
 
         Args:

--- a/src-tauri/backend/utils/mouse_utils.py
+++ b/src-tauri/backend/utils/mouse_utils.py
@@ -20,7 +20,7 @@ class MouseUtils:
 
     _hc = pyclick.HumanClicker()
     # The lower the more smooth, the higher the more accurate to the speed
-    mouse_smoothness = max(0.01, Settings.mouse_smoothness/100)
+    mouse_smoothness = max(0.01, Settings.mouse_smoothness / 100)
     # 1000 to 3000 is tested
     mouse_speed = max(1000.0, 1000.0 * Settings.custom_mouse_speed)
 
@@ -43,21 +43,21 @@ class MouseUtils:
         """
         if Settings.enable_bezier_curve_mouse_movement:
 
-            target_pos = (x,y)
+            target_pos = (x, y)
             pos = pyautogui.position()
             # estimate the mouse move distant with euclidean distant of 2 points
-            dist = [(a - b)**2 for a, b in zip(pos, target_pos)]
+            dist = [(a - b) ** 2 for a, b in zip(pos, target_pos)]
             dist = math.sqrt(sum(dist))
-            speed = MouseUtils.mouse_speed-np.random.randint(0,300)
+            speed = MouseUtils.mouse_speed - np.random.randint(0, 300)
             # calculate the duration of the mouse movement
-            dur = 0.1+dist/speed
-            target_point_cnt = int(dur/MouseUtils.mouse_smoothness)
+            dur = 0.1 + dist / speed
+            target_point_cnt = int(dur / MouseUtils.mouse_smoothness)
 
             if Settings.debug_mode:
                 MessageLog.print_message(
-                f"[DEBUG] Duration: {dur}, Number of points: {target_point_cnt})")
+                    f"[DEBUG] Duration: {dur}, Number of points: {target_point_cnt})")
 
-            curve = pyclick.HumanCurve(pos, target_pos, targetPoints=target_point_cnt)
+            curve = pyclick.HumanCurve(pos, target_pos, targetPoints = target_point_cnt)
 
             MouseUtils._hc.move((x, y), duration = dur, humanCurve = curve)
         else:
@@ -69,7 +69,7 @@ class MouseUtils:
         return None
 
     @staticmethod
-    def move_and_click_point(x: int, y: int, image_name: str, custom_mouse_speed: float = 0.0, mouse_clicks: int = np.random.randint(1,3), custom_wait: Optional[float]=None):
+    def move_and_click_point(x: int, y: int, image_name: str, custom_mouse_speed: float = 0.0, mouse_clicks: int = np.random.randint(1, 3), custom_wait: Optional[float] = None):
         """Move the cursor to the specified point on the screen and clicks it.
 
         Args:
@@ -90,13 +90,13 @@ class MouseUtils:
         if Settings.debug_mode:
             MessageLog.print_message(f"[DEBUG] New coordinates: ({new_x}, {new_y})")
 
-        MouseUtils.move_to(new_x,new_y, custom_mouse_speed=custom_mouse_speed)
-        
+        MouseUtils.move_to(new_x, new_y, custom_mouse_speed = custom_mouse_speed)
+
         pyautogui.mouseDown()
         sleep(np.random.uniform(0.02, 0.12))
         pyautogui.mouseUp()
-        for i in range (0, mouse_clicks-1):
-            sleep(np.random.uniform(0.08,0.16))
+        for i in range(0, mouse_clicks - 1):
+            sleep(np.random.uniform(0.08, 0.16))
             pyautogui.mouseDown()
             sleep(np.random.uniform(0.02, 0.12))
             pyautogui.mouseUp()
@@ -105,7 +105,7 @@ class MouseUtils:
         if custom_wait is not None:
             sleep(max(0, custom_wait))
             return
-                
+
         from bot.game import Game
         Game.wait(1)
 
@@ -121,15 +121,15 @@ class MouseUtils:
         Returns:
             (int, int): Tuple of the newly randomized location to click.
         """
-        from utils.image_utils import ImageUtils 
+        from utils.image_utils import ImageUtils
         # Get the width and height of the template image.
 
         if Settings.farming_mode.endswith("V2"):
             x_off, y_off, width, height = ImageUtils.get_clickable_area(image_name)
-            width = np.random.randint(0,width)
-            height = np.random.randint(0,height)
-            return x+x_off+width, y+y_off+height
-        
+            width = np.random.randint(0, width)
+            height = np.random.randint(0, height)
+            return x + x_off + width, y + y_off + height
+
         width, height = ImageUtils.get_button_dimensions(image_name)
 
         dimensions_x0 = x - (width // 2)
@@ -150,8 +150,6 @@ class MouseUtils:
                 break
 
         return new_x, new_y
-    
-
 
     @staticmethod
     def scroll_screen(x: int, y: int, scroll_clicks: int):

--- a/src-tauri/backend/utils/mouse_utils.py
+++ b/src-tauri/backend/utils/mouse_utils.py
@@ -78,7 +78,7 @@ class MouseUtils:
             image_name (str): File name of the image in /images/buttons/ folder.
             custom_mouse_speed (float, optional): Time in seconds it takes for the mouse to move to the specified point. Defaults to 0.0.
             mouse_clicks (int, optional): Number of mouse clicks. Defaults to 1.
-            custom_wait (float, optioanl): Custom wait time, useful for action not related to network speed & screenshot
+            custom_wait (float, optional): Custom wait time, useful for action not related to network speed & screenshot. Defaults to None.
         Returns:
             None
         """


### PR DESCRIPTION
## Description
- Fixes #196. The non-bezier mouse movement does not execute mouse clicks sometimes and this is fixed by reverting back to the old method of calling the `click()` method from pyautogui instead of using its `mouseDown()` and `mouseUp()`.